### PR TITLE
Small fixes and Sequential pattern

### DIFF
--- a/components/PatternSelect.html
+++ b/components/PatternSelect.html
@@ -1,5 +1,6 @@
 <select style="width:150px;">
-	<option value="-1">Random</option>
+	<option value="-2">Random</option>
+	<option value="-1" selected="selected">Sequential</option>
 	<option value="0">Paradeigma #1 (birds)</option>
 	<option value="1">Paradeigma #2 (birds/behemoths/aigedon)</option>
 	<option value="2">Paradeigma #3 (rotation/snakes/sigil)</option>

--- a/components/PatternSelect.html
+++ b/components/PatternSelect.html
@@ -4,9 +4,9 @@
 	<option value="1">Paradeigma #2 (birds/behemoths/aigedon)</option>
 	<option value="2">Paradeigma #3 (rotation/snakes/sigil)</option>
 	<option value="3">Paradeigma #4 (snakes/adikia)</option>
-	<option value="4">Paradeigma #5 (rotation/birds/behemoths/firewall)</option>
-	<option value="5">Paradeigma #6 (rotation/birds/snakes/firewall)</option>
-	<option value="6">Paradeigma #7 (rotation/snakes/firewall/sigil)</option>
-	<option value="7">Paradeigma #8 (rotation/birds/behemoths/firewall/sigil)</option>
-	<option value="8">Paradeigma #9 (rotation/birds/snakes/firewall/sigil)</option>
+	<option value="4">Paradeigma #5 (rotation/firewall/birds/behemoths)</option>
+	<option value="5">Paradeigma #6 (rotation/firewall/birds/snakes)</option>
+	<option value="6">Paradeigma #7 (rotation/firewall/snakes/sigil)</option>
+	<option value="7">Paradeigma #8 (rotation/firewall/birds/behemoths/sigil)</option>
+	<option value="8">Paradeigma #9 (rotation/firewall/birds/snakes/sigil)</option>
 </select>

--- a/js/classes/AdikiaPattern.js
+++ b/js/classes/AdikiaPattern.js
@@ -36,7 +36,7 @@ class AdikiaPattern extends Pattern
 
         this.scene.tweens.add({
             targets: this.images.getChildren(),
-            duration: constants.ANIMATION_DURATIONS.aigedon / 2,
+            duration: constants.ANIMATION_DURATIONS.adikia / 2,
             colorCounter: 100,
             ease: 'Linear',
             delay: this.animationDelay,

--- a/js/classes/AigedonPattern.js
+++ b/js/classes/AigedonPattern.js
@@ -61,7 +61,7 @@ class AigedonPattern extends Pattern
 
         this.scene.tweens.add({
             targets: this.images.getChildren(),
-            duration: constants.ANIMATION_DURATIONS.adikia / 2,
+            duration: constants.ANIMATION_DURATIONS.aigedon / 2,
             colorCounter: 100,
             ease: 'Linear',
             delay: this.animationDelay,

--- a/js/constants.js
+++ b/js/constants.js
@@ -41,36 +41,36 @@ const PATTERNS = [
     [
         // Paradeigma 5
         { type: 'rotation' },
-        { type: 'bird', count: 2 },
-        { type: 'firewall' }
+        { type: 'firewall' },
+        { type: 'bird', count: 2 }
     ],
     [
         // Paradeigma 6
         { type: 'rotation' },
+        { type: 'firewall' },
         { type: 'bird', count: 4 },
-        { type: 'snake' },
-        { type: 'firewall' }
+        { type: 'snake' }
     ],
     [
         // Paradeigma 7
         { type: 'rotation' },
-        { type: 'snake' },
         { type: 'firewall' },
+        { type: 'snake' },
         { type: 'sigil' }
     ],
     [
         // Paradeigma 8
         { type: 'rotation' },
-        { type: 'bird', count: 2, arrangement: 'across' },
         { type: 'firewall' },
+        { type: 'bird', count: 2, arrangement: 'across' },
         { type: 'sigil', side: 2, shape: 'square' }
     ],
     [
         // Paradeigma 9
         { type: 'rotation' },
+        { type: 'firewall' },
         { type: 'bird', count: 4 },
         { type: 'snake' },
-        { type: 'firewall' },
         { type: 'sigil' }
     ],
 ];

--- a/js/index.js
+++ b/js/index.js
@@ -217,17 +217,17 @@ function newPattern(scene) {
     let nextIndex = Math.floor(Math.random() * constants.PATTERNS.length);
     if (nextPattern >= 0 && nextPattern < constants.PATTERNS.length) {
         nextIndex = nextPattern;
-    } else if(nextPattern == -1) {
-		if (currentPattern == 8) {
-			nextIndex = 0;
-		} else {
-			nextIndex = ++currentPattern;
-		}
-	}
+    } else if (nextPattern == -1) {
+        if (currentPattern == 8) {
+            nextIndex = 0;
+        } else {
+            nextIndex = ++currentPattern;
+        }
+    }
     
     patterns = createPatternsFromConfig(scene, constants.PATTERNS[nextIndex]);
     currentPattern = nextIndex;
-	currentPatternText.text = 'Paradeigma #'+(++nextIndex);
+    currentPatternText.text = 'Paradeigma #'+(++nextIndex);
     //patterns = createPatternsFromConfig(scene, constants.PATTERNS[4]);
     /*patterns = createPatternsFromConfig(scene, [
         { type: 'sigil' }

--- a/js/index.js
+++ b/js/index.js
@@ -44,6 +44,7 @@ let confirmButton;
 let nextButton;
 let resultIcon;
 let patternSelect;
+let currentPattern = -1;
 let currentPatternText;
 let nextPattern = -1;
 
@@ -216,10 +217,17 @@ function newPattern(scene) {
     let nextIndex = Math.floor(Math.random() * constants.PATTERNS.length);
     if (nextPattern >= 0 && nextPattern < constants.PATTERNS.length) {
         nextIndex = nextPattern;
-    }
+    } else if(nextPattern == -1) {
+		if (currentPattern == 8) {
+			nextIndex = 0;
+		} else {
+			nextIndex = ++currentPattern;
+		}
+	}
     
     patterns = createPatternsFromConfig(scene, constants.PATTERNS[nextIndex]);
-    currentPatternText.text = 'Paradeigma #'+(++nextIndex);
+    currentPattern = nextIndex;
+	currentPatternText.text = 'Paradeigma #'+(++nextIndex);
     //patterns = createPatternsFromConfig(scene, constants.PATTERNS[4]);
     /*patterns = createPatternsFromConfig(scene, [
         { type: 'sigil' }


### PR DESCRIPTION
The changes included are:

- Made firewall resolve sooner, better reflecting the actual fight. This also makes it easier to learn from, since it can be very hard to see how it affected things at the end due to how much of the field is already red.
- Added a Sequential pattern as the new default. This goes through the attacks in order.
- I noticed Adikia and Aigedon had the wrong animation duration constants, so I swapped in the correct ones.

I made these changes forever ago back when I was learning the fight with friends. Now that I'm about to do it again with another set of friends, I thought I might as well make a PR.

(Looks like I also had some more changes half-finished on another branch, including a flashcard-like mode with no animations and a retry button, but I'm not sure if I'll have any time to clean that up soon.)